### PR TITLE
Allow passing keys to ReCaptchaField constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ class ReCaptchaWidget(Widget):
                  expired_callback=None, attrs={}, *args, **kwargs):
 ```
 
-If you set the explicit boolean to true, you will render this field with explicit render support. This is usefull if you
+If you set the explicit boolean to true, you will render this field with explicit render support. This is useful if you
 want to use multiple forms with reCaptcha in one page. Take a look to template and samples sections for more info.
 
 You can personalize reCaptcha theme, type, size, tabindex, callback and expired_callback parameters. Look the reCaptcha

--- a/snowpenguin/django/recaptcha2/fields.py
+++ b/snowpenguin/django/recaptcha2/fields.py
@@ -8,11 +8,23 @@ from django.utils.translation import ugettext_lazy as _
 
 import requests
 
+from snowpenguin.django.recaptcha2.widgets import ReCaptchaWidget
+
 logger = logging.getLogger(__name__)
 
 
 class ReCaptchaField(forms.CharField):
     def __init__(self, attrs={}, *args, **kwargs):
+        self._private_key = kwargs.pop('private_key', None)
+        public_key = kwargs.pop('public_key', None)
+
+        if 'widget' not in kwargs:
+            kwargs['widget'] = ReCaptchaWidget(public_key=public_key)
+        elif 'widget' in kwargs and public_key:
+            logger.warn('`public_key` kwarg supplied to ReCaptchaField constructor '
+                        'but a custom widget was specified. This value will be '
+                        'ignored.')
+
         super(ReCaptchaField, self).__init__(*args, **kwargs)
 
     def clean(self, values):
@@ -28,7 +40,7 @@ class ReCaptchaField(forms.CharField):
             r = requests.post(
                 'https://www.google.com/recaptcha/api/siteverify',
                 {
-                    'secret': settings.RECAPTCHA_PRIVATE_KEY,
+                    'secret': self.private_key or settings.RECAPTCHA_PRIVATE_KEY,
                     'response': response_token
                 },
                 timeout=5
@@ -62,3 +74,4 @@ class ReCaptchaField(forms.CharField):
                 raise ValidationError(
                     _('reCaptcha response from Google not valid, try again')
                 )
+

--- a/snowpenguin/django/recaptcha2/fields.py
+++ b/snowpenguin/django/recaptcha2/fields.py
@@ -40,7 +40,7 @@ class ReCaptchaField(forms.CharField):
             r = requests.post(
                 'https://www.google.com/recaptcha/api/siteverify',
                 {
-                    'secret': self.private_key or settings.RECAPTCHA_PRIVATE_KEY,
+                    'secret': self._private_key or settings.RECAPTCHA_PRIVATE_KEY,
                     'response': response_token
                 },
                 timeout=5

--- a/snowpenguin/django/recaptcha2/widgets.py
+++ b/snowpenguin/django/recaptcha2/widgets.py
@@ -6,7 +6,7 @@ from django.utils.safestring import mark_safe
 
 class ReCaptchaWidget(Widget):
     def __init__(self, explicit=False, theme=None, type=None, size=None, tabindex=None, callback=None,
-                 expired_callback=None, attrs={}, *args, **kwargs):
+                 expired_callback=None, public_key=None, attrs={}, *args, **kwargs):
         super(ReCaptchaWidget, self).__init__(*args, **kwargs)
         self.explicit = explicit
         self.theme = theme
@@ -16,6 +16,7 @@ class ReCaptchaWidget(Widget):
         self.callback = callback
         self.expired_callback = expired_callback
         self.attrs = attrs
+        self._public_key = public_key
 
     def render(self, name, value, attrs=None):
         template = 'snowpenguin/recaptcha/'
@@ -24,7 +25,7 @@ class ReCaptchaWidget(Widget):
         return mark_safe(
             render_to_string(template, {
                 'container_id': 'id_%s' % name,
-                'public_key': settings.RECAPTCHA_PUBLIC_KEY,
+                'public_key': self._public_key or settings.RECAPTCHA_PUBLIC_KEY,
                 'theme': self.theme,
                 'type': self.type,
                 'size': self.size,


### PR DESCRIPTION
Addresses issue #13. Also will construct a ReCaptchaWidget for a ReCaptchaField if no widget is explicitly specified.