### PR TITLE
Added **kwargs in widget render() method to be compatible with Django 2.1

### DIFF
--- a/snowpenguin/django/recaptcha2/widgets.py
+++ b/snowpenguin/django/recaptcha2/widgets.py
@@ -18,7 +18,7 @@ class ReCaptchaWidget(Widget):
         self.attrs = attrs
         self._public_key = public_key
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, *args, **kwargs):
         template = 'snowpenguin/recaptcha/'
         template += 'recaptcha_explicit.html' if self.explicit else 'recaptcha_automatic.html'
 


### PR DESCRIPTION
Otherwise, an exception may occur when rendering the reCaptcha2 widget with Django 2.1.

It should corrects Issue #18 