### PR TITLE
Django 2.1 compatibility.

### DIFF
--- a/snowpenguin/django/recaptcha2/widgets.py
+++ b/snowpenguin/django/recaptcha2/widgets.py
@@ -18,7 +18,7 @@ class ReCaptchaWidget(Widget):
         self.attrs = attrs
         self._public_key = public_key
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         template = 'snowpenguin/recaptcha/'
         template += 'recaptcha_explicit.html' if self.explicit else 'recaptcha_automatic.html'
 


### PR DESCRIPTION
This fixes issues #18 .

Added `renderer` argument to `ReCaptchaWidget.render` method.

Django has removed support for Widget.render() methods without the renderer argument.
https://docs.djangoproject.com/en/2.1/releases/2.1/#features-removed-in-2-1