### PR TITLE
Replace uggettext_lazy with gettext_lazy to support Django 4.0

### DIFF
--- a/snowpenguin/django/recaptcha2/fields.py
+++ b/snowpenguin/django/recaptcha2/fields.py
@@ -4,7 +4,7 @@ import os
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 import requests
 

--- a/snowpenguin/django/recaptcha2/templatetags/recaptcha2.py
+++ b/snowpenguin/django/recaptcha2/templatetags/recaptcha2.py
@@ -2,7 +2,7 @@ from random import randint
 
 from django import template
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 register = template.Library()
 


### PR DESCRIPTION
> django.utils.translation.ugettext(), ugettext_lazy(), ugettext_noop(),
ungettext(), and ungettext_lazy() are removed.

https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0

Django trac ticket: https://code.djangoproject.com/ticket/30165